### PR TITLE
added clear_persistent_cache and minor update to persistent caching

### DIFF
--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -516,7 +516,8 @@ public:
                 << "// " << options << "\n\n"
                 << source;
 
-            hash = detail::sha1(src.str());
+            // Gets rebuilt if either source, or device (indicated by name) or compile options change
+            hash = detail::sha1(src.str() + context.device.name().str() + options.str());
         }
 
         // Try to get cached program binaries:

--- a/include/boost/compute/utility/program_cache.hpp
+++ b/include/boost/compute/utility/program_cache.hpp
@@ -82,6 +82,25 @@ public:
         m_cache.clear();
     }
 
+    /// Clears persistent cache by deleting the boost_compute folder
+    void clear_persistent_cache()
+    {
+#ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
+        // Path delimiter symbol for the current OS.
+        static const std::string delim = boost::filesystem::path("/").make_preferred().string();
+
+        // Path to appdata folder.
+#ifdef WIN32
+        static const std::string appdata = detail::getenv("APPDATA") 
+            + delim + "boost_compute";
+#else
+        static const std::string appdata = detail::getenv("HOME")
+            + delim + ".boost_compute";
+#endif
+        boost::filesystem::remove_all(appdata);
+#endif
+    }
+
     /// Returns the program object with \p key. Returns a null optional if no
     /// program with \p key exists in the cache.
     boost::optional<program> get(const std::string &key)


### PR DESCRIPTION
Added ```clear_persistent_cache()``` in ```program_cache.hpp``` which removes ```.boost_compute``` directory.

Minor update to persistent caching: instead of computing sha1 hash of just program source, I've also added compiler options and selected device's name so if anything changes, program would be built again.