### PR TITLE
Persistent cache

### DIFF
--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -505,20 +505,24 @@ public:
     {
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
         // Get hash string for the kernel.
-        std::string hash;
-        {
-            device   d(context.get_device());
-            platform p = d.platform();
+        // std::string hash;
+        // {
+        //     device   d(context.get_device());
+        //     platform p = d.platform();
 
-            std::ostringstream src;
-            src << "// " << p.name() << " v" << p.version() << "\n"
-                << "// " << context.get_device().name() << "\n"
-                << "// " << options << "\n\n"
-                << source;
+        //     std::ostringstream src;
+        //     src << "// " << p.name() << " v" << p.version() << "\n"
+        //         << "// " << context.get_device().name() << "\n"
+        //         << "// " << options << "\n\n"
+        //         << source;
+        // }
 
-            // Gets rebuilt if either source, or device (indicated by name) or compile options change
-            hash = detail::sha1(src.str() + context.device.name().str() + options.str());
-        }
+        boost::detail::sha1 hash;
+        hash(p.name());
+        hash(p.version());
+        hash(context.get_device().name());
+        hash(options);
+        hash(source);
 
         // Try to get cached program binaries:
         try {

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -516,7 +516,8 @@ public:
                 << "// " << options << "\n\n"
                 << source;
 
-            hash = detail::sha1(src.str());
+            // Gets rebuilt if either source, or device (indicated by name) or compile options change
+            hash = detail::sha1(src.str() + context.device.name().str() + options.str());
         }
 
         // Try to get cached program binaries:

--- a/include/boost/compute/utility/program_cache.hpp
+++ b/include/boost/compute/utility/program_cache.hpp
@@ -83,7 +83,7 @@ public:
     }
 
     /// Clears persistent cache by deleting the boost_compute folder
-    void clear_persistent_cache()
+    static void clear_persistent_cache()
     {
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
         // Path delimiter symbol for the current OS.
@@ -97,7 +97,17 @@ public:
         static const std::string appdata = detail::getenv("HOME")
             + delim + ".boost_compute";
 #endif
-        boost::filesystem::remove_all(appdata);
+        try
+        {
+            if(boost::filesystem::exists(appdata))
+            {
+               boost::filesystem::remove_all(appdata);
+            }  
+        }
+        catch(boost::filesystem::filesystem_error const & err)
+        {
+            std::cout<<err.what()<<std::endl;
+        }
 #endif
     }
 

--- a/include/boost/compute/utility/program_cache.hpp
+++ b/include/boost/compute/utility/program_cache.hpp
@@ -82,6 +82,25 @@ public:
         m_cache.clear();
     }
 
+    /// Clears persistent cache by deleting the boost_compute folder
+    void clear_persistent_cache()
+    {
+#ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
+        // Path delimiter symbol for the current OS.
+        static const std::string delim = boost::filesystem::path("/").make_preferred().string();
+
+        // Path to appdata folder.
+#ifdef WIN32
+        static const std::string appdata = detail::getenv("APPDATA") 
+            + delim + "boost_compute";
+#else
+        static const std::string appdata = detail::getenv("HOME")
+            + delim + ".boost_compute";
+#endif
+        boost::filesystem::remove_all(appdata);
+#endif
+    }
+
     /// Returns the program object with \p key. Returns a null optional if no
     /// program with \p key exists in the cache.
     boost::optional<program> get(const std::string &key)


### PR DESCRIPTION
*    Made ```clear_persistent_cache``` static
*    Catching exception if there's no ```.boost_compute``` folder (or in use)
*    Followed @ddemidov suggestion on computing hash for persistent cache lookup

@kylelutz have to re-use ```appdata``` path snippet since ```appdata_path()``` is private within ```program``` but ```clear_persistent_cache``` suits better in ```program_cache```.