### PR TITLE
Backwards compatibility

### DIFF
--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -1071,6 +1071,7 @@ public:
                                   cl_event * clevent = NULL)
     {
         BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(work_dim > 0);
         BOOST_ASSERT(kernel.get_context() == this->get_context());
 
         cl_int ret = clEnqueueNDRangeKernel(
@@ -1099,12 +1100,13 @@ public:
                                   const wait_list &events = wait_list(),
                                   cl_event * clevent = NULL)
     {
+        BOOST_STATIC_ASSERT(N > 0);
         enqueue_nd_range_kernel(
             kernel,
             N,
             global_work_offset.data(),
             global_work_size.data(),
-            local_work_size.data(),
+            (local_work_size[0] == 0) ? NULL : local_work_size.data(),
             events,
             clevent
         );

--- a/include/boost/compute/context.hpp
+++ b/include/boost/compute/context.hpp
@@ -50,7 +50,7 @@ class context
 public:
     /// Create a null context object.
     context()
-        : m_context(0)
+        : m_context(0), m_version(0)
     {
     }
 
@@ -64,6 +64,7 @@ public:
 
         cl_device_id device_id = device.id();
 
+        m_version = 0;
         cl_int error = 0;
         m_context = clCreateContext(properties, 1, &device_id, 0, 0, &error);
 
@@ -82,6 +83,7 @@ public:
 
         cl_int error = 0;
 
+        m_version = 0;
         m_context = clCreateContext(
             properties,
             static_cast<cl_uint>(devices.size()),
@@ -99,7 +101,7 @@ public:
     /// Creates a new context object for \p context. If \p retain is
     /// \c true, the reference count for \p context will be incremented.
     explicit context(cl_context context, bool retain = true)
-        : m_context(context)
+        : m_context(context), m_version(0)
     {
         if(m_context && retain){
             clRetainContext(m_context);
@@ -123,6 +125,7 @@ public:
                 clReleaseContext(m_context);
             }
 
+            m_version = other.m_version;
             m_context = other.m_context;
 
             if(m_context){
@@ -136,9 +139,10 @@ public:
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new context object from \p other.
     context(context&& other) BOOST_NOEXCEPT
-        : m_context(other.m_context)
+        : m_context(other.m_context), m_version(other.m_version)
     {
         other.m_context = 0;
+        other.m_version = 0;
     }
 
     /// Move-assigns the context from \p other to \c *this.
@@ -148,7 +152,9 @@ public:
             clReleaseContext(m_context);
         }
 
+        m_version = other.m_version;
         m_context = other.m_context;
+        other.m_version = 0;
         other.m_context = 0;
 
         return *this;
@@ -236,8 +242,17 @@ public:
         return m_context;
     }
 
+    /// Returns the device version number. (eg. 1.1 is 101, 1.2 is 102, 2.0 is 200)
+    uint_ version_number() const
+    {
+        if (m_version == 0)
+            m_version = get_device().version_number(); // The version of the first device
+        return m_version;
+    }
+
 private:
     cl_context m_context;
+    mutable uint_ m_version; // Cached ICD OpenCL version number
 };
 
 /// \internal_ define get_info() specializations for context

--- a/include/boost/compute/context.hpp
+++ b/include/boost/compute/context.hpp
@@ -243,10 +243,10 @@ public:
     }
 
     /// Returns the device version number. (eg. 1.1 is 101, 1.2 is 102, 2.0 is 200)
-    uint_ version_number() const
+    uint_ get_version() const
     {
         if (m_version == 0)
-            m_version = get_device().version_number(); // The version of the first device
+            m_version = get_device().get_version(); // The version of the first device
         return m_version;
     }
 

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -52,14 +52,14 @@ public:
 
     /// Creates a null device object.
     device()
-        : m_id(0)
+        : m_id(0), m_version(0)
     {
     }
 
     /// Creates a new device object for \p id. If \p retain is \c true,
     /// the reference count for the device will be incremented.
     explicit device(cl_device_id id, bool retain = true)
-        : m_id(id)
+        : m_id(id), m_version(0)
     {
         #ifdef CL_VERSION_1_2
         if(m_id && retain && is_subdevice()){
@@ -72,7 +72,7 @@ public:
 
     /// Creates a new device object as a copy of \p other.
     device(const device &other)
-        : m_id(other.m_id)
+        : m_id(other.m_id), m_version(other.m_version)
     {
         #ifdef CL_VERSION_1_2
         if(m_id && is_subdevice()){
@@ -118,7 +118,7 @@ public:
         if(m_id && is_subdevice()){
             clReleaseDevice(m_id);
         }
-        #endif
+        #endif // CL_VERSION_1_2
 
         m_id = other.m_id;
         other.m_id = 0;
@@ -136,7 +136,7 @@ public:
                 clReleaseDevice(m_id)
             );
         }
-        #endif
+        #endif // CL_VERSION_1_2
     }
 
     /// Returns the ID of the device.
@@ -186,6 +186,21 @@ public:
     std::string version() const
     {
         return get_info<std::string>(CL_DEVICE_VERSION);
+    }
+
+    /// Returns the device version number. (eg. 1.1 is 101, 1.2 is 102, 2.0 is 200)
+    uint_ version_number() const
+    {
+        if (m_version == 0) {
+            std::stringstream ss(version());
+            ushort_ major, minor;
+            ss.ignore(7); // 'OpenCL '
+            ss >> major;
+            ss.ignore(1); // '.'
+            ss >> minor;
+            m_version = major * 100 + minor; // cache
+        }
+        return m_version;
     }
 
     /// Returns the driver version string.
@@ -281,17 +296,11 @@ public:
     bool is_subdevice() const
     {
     #if defined(CL_VERSION_1_2)
-        try {
+        if (version_number() >= 102)
             return get_info<cl_device_id>(CL_DEVICE_PARENT_DEVICE) != 0;
-        }
-        catch(opencl_error&){
-            // the get_info() call above will throw if the device's opencl version
-            // is less than 1.2 (in which case it can't be a sub-device).
+        else
+    #endif // CL_VERSION_1_2
             return false;
-        }
-    #else
-        return false;
-    #endif
     }
 
     /// Returns information about the device.
@@ -327,6 +336,9 @@ public:
     std::vector<device>
     partition(const cl_device_partition_property *properties) const
     {
+        if (version_number() < 102)
+            return std::vector<device>();
+
         // get sub-device count
         uint_ count = 0;
         int_ ret = clCreateSubDevices(m_id, properties, 0, 0, &count);
@@ -405,24 +417,9 @@ public:
         return m_id != other.m_id;
     }
 
-    /// \internal_
-    bool check_version(int major, int minor) const
-    {
-        std::stringstream stream;
-        stream << version();
-
-        int actual_major, actual_minor;
-        stream.ignore(7); // 'OpenCL '
-        stream >> actual_major;
-        stream.ignore(1); // '.'
-        stream >> actual_minor;
-
-        return actual_major > major ||
-               (actual_major == major && actual_minor >= minor);
-    }
-
 private:
     cl_device_id m_id;
+    mutable uint_ m_version; // Cached ICD OpenCL version number
 };
 
 /// \internal_

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -92,6 +92,7 @@ public:
             #endif
 
             m_id = other.m_id;
+            m_version = other.m_version;
 
             #ifdef CL_VERSION_1_2
             if(m_id && is_subdevice()){
@@ -106,9 +107,10 @@ public:
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new device object from \p other.
     device(device&& other) BOOST_NOEXCEPT
-        : m_id(other.m_id)
+        : m_id(other.m_id),  m_version(other.m_version)
     {
         other.m_id = 0;
+        other.m_version = 0;
     }
 
     /// Move-assigns the device from \p other to \c *this.
@@ -121,7 +123,9 @@ public:
         #endif // CL_VERSION_1_2
 
         m_id = other.m_id;
+        m_version = other.m_version;
         other.m_id = 0;
+        other.m_version = 0;
 
         return *this;
     }

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -188,11 +188,12 @@ public:
         return get_info<std::string>(CL_DEVICE_VERSION);
     }
 
-    /// Returns the device version number. (eg. 1.1 is 101, 1.2 is 102, 2.0 is 200)
-    uint_ version_number() const
+    /// Returns the device version number: major * 100 + minor (eg. 1.1 is 101, 1.2 is 102, 2.0 is 200)
+    uint_ get_version() const
     {
         if (m_version == 0) {
-            std::stringstream ss(version());
+            std::string strversion(version());
+            std::stringstream ss(strversion);
             ushort_ major, minor;
             ss.ignore(7); // 'OpenCL '
             ss >> major;
@@ -296,7 +297,7 @@ public:
     bool is_subdevice() const
     {
     #if defined(CL_VERSION_1_2)
-        if (version_number() >= 102)
+        if (get_version() >= 102)
             return get_info<cl_device_id>(CL_DEVICE_PARENT_DEVICE) != 0;
         else
     #endif // CL_VERSION_1_2
@@ -336,7 +337,7 @@ public:
     std::vector<device>
     partition(const cl_device_partition_property *properties) const
     {
-        if (version_number() < 102)
+        if (get_version() < 102)
             return std::vector<device>();
 
         // get sub-device count

--- a/include/boost/compute/exception/context_error.hpp
+++ b/include/boost/compute/exception/context_error.hpp
@@ -70,7 +70,7 @@ public:
     }
 
     /// Returns the size of the private info memory block.
-    const size_t get_private_info_size() const throw()
+    size_t get_private_info_size() const throw()
     {
         return m_private_info_size;
     }

--- a/include/boost/compute/image/image1d.hpp
+++ b/include/boost/compute/image/image1d.hpp
@@ -51,35 +51,38 @@ public:
             void *host_ptr = 0)
     {
     #ifdef CL_VERSION_1_2
-        cl_image_desc desc;
-        desc.image_type = CL_MEM_OBJECT_IMAGE1D;
-        desc.image_width = image_width;
-        desc.image_height = 1;
-        desc.image_depth = 1;
-        desc.image_array_size = 0;
-        desc.image_row_pitch = 0;
-        desc.image_slice_pitch = 0;
-        desc.num_mip_levels = 0;
-        desc.num_samples = 0;
-    #ifdef CL_VERSION_2_0
-        desc.mem_object = 0;
-    #else
-        desc.buffer = 0;
-    #endif
+        if (context.version_number() >= 102)
+        {
+            cl_image_desc desc;
+            desc.image_type = CL_MEM_OBJECT_IMAGE1D;
+            desc.image_width = image_width;
+            desc.image_height = 1;
+            desc.image_depth = 1;
+            desc.image_array_size = 0;
+            desc.image_row_pitch = 0;
+            desc.image_slice_pitch = 0;
+            desc.num_mip_levels = 0;
+            desc.num_samples = 0;
+            #ifdef CL_VERSION_2_0
+            desc.mem_object = 0;
+            #else
+            desc.buffer = 0;
+            #endif
 
-        cl_int error = 0;
+            cl_int error = 0;
 
-        m_mem = clCreateImage(
-            context, flags, format.get_format_ptr(), &desc, host_ptr, &error
-        );
+            m_mem = clCreateImage(
+                        context, flags, format.get_format_ptr(), &desc, host_ptr, &error
+                        );
 
-        if(!m_mem){
-            BOOST_THROW_EXCEPTION(opencl_error(error));
+            if(!m_mem){
+                BOOST_THROW_EXCEPTION(opencl_error(error));
+            }
         }
-    #else
+        else
+    #endif
         // image1d objects are only supported in OpenCL 1.2 and later
         BOOST_THROW_EXCEPTION(opencl_error(CL_IMAGE_FORMAT_NOT_SUPPORTED));
-    #endif
     }
 
     /// Creates a new image1d as a copy of \p other.

--- a/include/boost/compute/image/image1d.hpp
+++ b/include/boost/compute/image/image1d.hpp
@@ -51,7 +51,7 @@ public:
             void *host_ptr = 0)
     {
     #ifdef CL_VERSION_1_2
-        if (context.version_number() >= 102)
+        if (context.get_version() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE1D;

--- a/include/boost/compute/image/image2d.hpp
+++ b/include/boost/compute/image/image2d.hpp
@@ -59,7 +59,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.get_device().version_number() >= 102)
+        if (context.version_number() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE2D;
@@ -114,7 +114,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.get_device().version_number() >= 102)
+        if (context.version_number() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE2D;

--- a/include/boost/compute/image/image2d.hpp
+++ b/include/boost/compute/image/image2d.hpp
@@ -59,38 +59,43 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        cl_image_desc desc;
-        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
-        desc.image_width = image_width;
-        desc.image_height = image_height;
-        desc.image_depth = 1;
-        desc.image_array_size = 0;
-        desc.image_row_pitch = image_row_pitch;
-        desc.image_slice_pitch = 0;
-        desc.num_mip_levels = 0;
-        desc.num_samples = 0;
-        #ifdef CL_VERSION_2_0
-        desc.mem_object = 0;
-        #else
-        desc.buffer = 0;
-        #endif
+        if (context.get_device().version_number() >= 102)
+        {
+            cl_image_desc desc;
+            desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+            desc.image_width = image_width;
+            desc.image_height = image_height;
+            desc.image_depth = 1;
+            desc.image_array_size = 0;
+            desc.image_row_pitch = image_row_pitch;
+            desc.image_slice_pitch = 0;
+            desc.num_mip_levels = 0;
+            desc.num_samples = 0;
+            #ifdef CL_VERSION_2_0
+            desc.mem_object = 0;
+            #else
+            desc.buffer = 0;
+            #endif
 
-        m_mem = clCreateImage(context,
-                              flags,
-                              format.get_format_ptr(),
-                              &desc,
-                              host_ptr,
-                              &error);
-        #else
-        m_mem = clCreateImage2D(context,
-                                flags,
-                                format.get_format_ptr(),
-                                image_width,
-                                image_height,
-                                image_row_pitch,
-                                host_ptr,
-                                &error);
+            m_mem = clCreateImage(context,
+                                  flags,
+                                  format.get_format_ptr(),
+                                  &desc,
+                                  host_ptr,
+                                  &error);
+        }
+        else
         #endif
+        {
+            m_mem = clCreateImage2D(context,
+                                    flags,
+                                    format.get_format_ptr(),
+                                    image_width,
+                                    image_height,
+                                    image_row_pitch,
+                                    host_ptr,
+                                    &error);
+        }
 
         if(!m_mem){
             BOOST_THROW_EXCEPTION(opencl_error(error));
@@ -109,38 +114,43 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        cl_image_desc desc;
-        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
-        desc.image_width = image_width;
-        desc.image_height = image_height;
-        desc.image_depth = 1;
-        desc.image_array_size = 0;
-        desc.image_row_pitch = image_row_pitch;
-        desc.image_slice_pitch = 0;
-        desc.num_mip_levels = 0;
-        desc.num_samples = 0;
-        #ifdef CL_VERSION_2_0
-        desc.mem_object = 0;
-        #else
-        desc.buffer = 0;
-        #endif
+        if (context.get_device().version_number() >= 102)
+        {
+            cl_image_desc desc;
+            desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+            desc.image_width = image_width;
+            desc.image_height = image_height;
+            desc.image_depth = 1;
+            desc.image_array_size = 0;
+            desc.image_row_pitch = image_row_pitch;
+            desc.image_slice_pitch = 0;
+            desc.num_mip_levels = 0;
+            desc.num_samples = 0;
+            #ifdef CL_VERSION_2_0
+            desc.mem_object = 0;
+            #else
+            desc.buffer = 0;
+            #endif
 
-        m_mem = clCreateImage(context,
-                              flags,
-                              format.get_format_ptr(),
-                              &desc,
-                              host_ptr,
-                              &error);
-        #else
-        m_mem = clCreateImage2D(context,
-                                flags,
-                                format.get_format_ptr(),
-                                image_width,
-                                image_height,
-                                image_row_pitch,
-                                host_ptr,
-                                &error);
+            m_mem = clCreateImage(context,
+                                  flags,
+                                  format.get_format_ptr(),
+                                  &desc,
+                                  host_ptr,
+                                  &error);
+        }
+        else
         #endif
+        {
+            m_mem = clCreateImage2D(context,
+                                    flags,
+                                    format.get_format_ptr(),
+                                    image_width,
+                                    image_height,
+                                    image_row_pitch,
+                                    host_ptr,
+                                    &error);
+        }
 
         if(!m_mem){
             BOOST_THROW_EXCEPTION(opencl_error(error));

--- a/include/boost/compute/image/image2d.hpp
+++ b/include/boost/compute/image/image2d.hpp
@@ -59,7 +59,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.version_number() >= 102)
+        if (context.get_version() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE2D;
@@ -114,7 +114,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.version_number() >= 102)
+        if (context.get_version() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE2D;

--- a/include/boost/compute/image/image3d.hpp
+++ b/include/boost/compute/image/image3d.hpp
@@ -52,29 +52,33 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        cl_image_desc desc;
-        desc.image_type = CL_MEM_OBJECT_IMAGE3D;
-        desc.image_width = image_width;
-        desc.image_height = image_height;
-        desc.image_depth = image_depth;
-        desc.image_array_size = 0;
-        desc.image_row_pitch = image_row_pitch;
-        desc.image_slice_pitch = image_slice_pitch;
-        desc.num_mip_levels = 0;
-        desc.num_samples = 0;
-        #ifdef CL_VERSION_2_0
-        desc.mem_object = 0;
-        #else
-        desc.buffer = 0;
-        #endif
+        if (context.version_number() >= 102)
+        {
+            cl_image_desc desc;
+            desc.image_type = CL_MEM_OBJECT_IMAGE3D;
+            desc.image_width = image_width;
+            desc.image_height = image_height;
+            desc.image_depth = image_depth;
+            desc.image_array_size = 0;
+            desc.image_row_pitch = image_row_pitch;
+            desc.image_slice_pitch = image_slice_pitch;
+            desc.num_mip_levels = 0;
+            desc.num_samples = 0;
+            #ifdef CL_VERSION_2_0
+            desc.mem_object = 0;
+            #else
+            desc.buffer = 0;
+            #endif
 
-        m_mem = clCreateImage(context,
-                              flags,
-                              format.get_format_ptr(),
-                              &desc,
-                              host_ptr,
-                              &error);
-        #else
+            m_mem = clCreateImage(context,
+                                  flags,
+                                  format.get_format_ptr(),
+                                  &desc,
+                                  host_ptr,
+                                  &error);
+        }
+        else
+        #endif
         m_mem = clCreateImage3D(context,
                                 flags,
                                 format.get_format_ptr(),
@@ -85,7 +89,6 @@ public:
                                 image_slice_pitch,
                                 host_ptr,
                                 &error);
-        #endif
 
         if(!m_mem){
             BOOST_THROW_EXCEPTION(opencl_error(error));
@@ -106,29 +109,33 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        cl_image_desc desc;
-        desc.image_type = CL_MEM_OBJECT_IMAGE3D;
-        desc.image_width = image_width;
-        desc.image_height = image_height;
-        desc.image_depth = image_depth;
-        desc.image_array_size = 0;
-        desc.image_row_pitch = image_row_pitch;
-        desc.image_slice_pitch = image_slice_pitch;
-        desc.num_mip_levels = 0;
-        desc.num_samples = 0;
-        #ifdef CL_VERSION_2_0
-        desc.mem_object = 0;
-        #else
-        desc.buffer = 0;
-        #endif
+        if (context.version_number() >= 102)
+        {
+            cl_image_desc desc;
+            desc.image_type = CL_MEM_OBJECT_IMAGE3D;
+            desc.image_width = image_width;
+            desc.image_height = image_height;
+            desc.image_depth = image_depth;
+            desc.image_array_size = 0;
+            desc.image_row_pitch = image_row_pitch;
+            desc.image_slice_pitch = image_slice_pitch;
+            desc.num_mip_levels = 0;
+            desc.num_samples = 0;
+            #ifdef CL_VERSION_2_0
+            desc.mem_object = 0;
+            #else
+            desc.buffer = 0;
+            #endif
 
-        m_mem = clCreateImage(context,
-                              flags,
-                              format.get_format_ptr(),
-                              &desc,
-                              host_ptr,
-                              &error);
-        #else
+            m_mem = clCreateImage(context,
+                                  flags,
+                                  format.get_format_ptr(),
+                                  &desc,
+                                  host_ptr,
+                                  &error);
+        }
+        else
+        #endif
         m_mem = clCreateImage3D(context,
                                 flags,
                                 format.get_format_ptr(),
@@ -139,7 +146,6 @@ public:
                                 image_slice_pitch,
                                 host_ptr,
                                 &error);
-        #endif
 
         if(!m_mem){
             BOOST_THROW_EXCEPTION(opencl_error(error));

--- a/include/boost/compute/image/image3d.hpp
+++ b/include/boost/compute/image/image3d.hpp
@@ -52,7 +52,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.version_number() >= 102)
+        if (context.get_version() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE3D;
@@ -109,7 +109,7 @@ public:
         cl_int error = 0;
 
         #ifdef CL_VERSION_1_2
-        if (context.version_number() >= 102)
+        if (context.get_version() >= 102)
         {
             cl_image_desc desc;
             desc.image_type = CL_MEM_OBJECT_IMAGE3D;

--- a/include/boost/compute/utility/wait_list.hpp
+++ b/include/boost/compute/utility/wait_list.hpp
@@ -97,7 +97,7 @@ public:
     /// Returns the number of events in the wait-list.
     uint_ size() const
     {
-        return m_events.size();
+        return static_cast<uint_>(m_events.size());
     }
 
     /// Removes all of the events from the wait-list.


### PR DESCRIPTION
This pull gives compatibility at runtime with ICDs supporting old OpenCL versions (NVIDIA).
Using of a fast version checking.
Adds support for mapping images.