### PR TITLE
Offline cache optimization

### DIFF
--- a/include/boost/compute/detail/meta_kernel.hpp
+++ b/include/boost/compute/detail/meta_kernel.hpp
@@ -335,7 +335,8 @@ public:
         std::string source = this->source();
 
         // generate cache key
-        std::string cache_key = "__boost_meta_kernel_" + detail::sha1(source);
+        std::string cache_key = "__boost_meta_kernel_" +
+            static_cast<std::string>(detail::sha1(source));
 
         // load program cache
         boost::shared_ptr<program_cache> cache =

--- a/include/boost/compute/detail/sha1.hpp
+++ b/include/boost/compute/detail/sha1.hpp
@@ -19,20 +19,31 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-// Returns SHA1 hash of the string parameter.
-inline std::string sha1(const std::string &src) {
-    boost::uuids::detail::sha1 sha1;
-    sha1.process_bytes(src.c_str(), src.size());
+// Accumulates SHA1 hash of the passed strings.
+class sha1 {
+    public:
+        sha1(const std::string &s = "") {
+            if (!s.empty()) this->process(s);
+        }
 
-    unsigned int hash[5];
-    sha1.get_digest(hash);
+        sha1& process(const std::string &s) {
+            h.process_bytes(s.c_str(), s.size());
+            return *this;
+        }
 
-    std::ostringstream buf;
-    for(int i = 0; i < 5; ++i)
-        buf << std::hex << std::setfill('0') << std::setw(8) << hash[i];
+        operator std::string() {
+            unsigned int digest[5];
+            h.get_digest(digest);
 
-    return buf.str();
-}
+            std::ostringstream buf;
+            for(int i = 0; i < 5; ++i)
+                buf << std::hex << std::setfill('0') << std::setw(8) << digest[i];
+
+            return buf.str();
+        }
+    private:
+        boost::uuids::detail::sha1 h;
+};
 
 } // end detail namespace
 } // end compute namespace

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -505,19 +505,16 @@ public:
     {
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
         // Get hash string for the kernel.
-        std::string hash;
-        {
-            device   d(context.get_device());
-            platform p = d.platform();
+        device   d = context.get_device();
+        platform p = d.platform();
 
-            std::ostringstream src;
-            src << "// " << p.name() << " v" << p.version() << "\n"
-                << "// " << context.get_device().name() << "\n"
-                << "// " << options << "\n\n"
-                << source;
-
-            hash = detail::sha1(src.str());
-        }
+        detail::sha1 hash;
+        hash.process( p.name()    )
+            .process( p.version() )
+            .process( d.name()    )
+            .process( options     )
+            .process( source      )
+            ;
 
         // Try to get cached program binaries:
         try {


### PR DESCRIPTION
This gets rid of temporary strings allocation in implementation of offline cache. See #440, #441 for details.