### PR TITLE
Add strided_iterator class (skip_iterator) #121

### DIFF
--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -106,7 +106,7 @@ inline meta_kernel& operator<<(meta_kernel &kernel,
 /// \class strided_iterator
 /// \brief Iterator adaptor which skips over multiple elements each time it is incremented.
 ///
-/// TODO
+/// TODO: Description
 ///
 ///
 /// \see buffer_iterator, make_strided_iterator()
@@ -127,7 +127,7 @@ public:
           m_stride(static_cast<difference_type>(stride))
     {
         // stride must be greater than zero
-        BOOST_ASSERT_MSG(stride > 0, "Stride value must be greater than zero");
+        BOOST_ASSERT_MSG(stride > 0, "Stride must be greater than zero");
     }
 
     strided_iterator(const strided_iterator<Iterator> &other)
@@ -213,15 +213,15 @@ private:
 
 /// Returns a strided_iterator for \p iterator with \p stride.
 ///
-/// TODO: Better description.
+/// TODO: Description
 ///
 /// \param iterator
 /// \param stride
 ///
 /// \return a \c strided_iterator for \p iterator with \p stride.
 ///
-/// For example, to create an iterator which iterates over every second
-/// value in a \c vector<int>:
+/// For example, to create an iterator which iterates over every other
+/// element in a \c vector<int>:
 /// \code
 /// auto strided_iterator = make_strided_iterator(vec.begin(), 2);
 /// \endcode
@@ -230,6 +230,53 @@ inline strided_iterator<Iterator>
 make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>::difference_type stride)
 {
     return strided_iterator<Iterator>(iterator, stride);
+}
+
+/// Returns a strided_iterator which refers to element that would follow
+/// the last element accessible through strided_iterator for \p first iterator
+/// with \p stride.
+///
+/// \param first the iterator referring to the first element accessible
+///        through strided_iterator for \p first with \p stride
+/// \param last the iterator referring to the last element that may be accessible
+///        through strided_iterator for \p first with \p stride
+/// \param stride the iteration step
+///
+/// \return a \c strided_iterator referring to element that would follow
+///         the last element accessible through strided_iterator for \p first
+///         iterator with \p stride.
+///
+/// It can be helpful when iterating over strided_iterator:
+/// \code
+/// // vec.size() may not be divisible by 3
+/// auto strided_iterator_begin = make_strided_iterator(vec.begin(), 3);
+/// auto strided_iterator_end = make_strided_iterator_end(vec.end(), 3);
+///
+/// // copy every 3rd element to result
+/// boost::compute::copy(
+///         strided_iterator_begin,
+///         strided_iterator_end,
+///         result.begin(),
+///         queue
+/// );
+/// \endcode
+template<class Iterator>
+strided_iterator<Iterator>
+make_strided_iterator_end(Iterator first, Iterator last, typename std::iterator_traits<Iterator>::difference_type stride)
+{
+    typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
+
+    // calculate distance from end to the last element that would be
+    // accessible through strided_iterator.
+    difference_type range = std::distance(first, last);
+    difference_type d = (range - 1) / stride;
+    d *= stride;
+    d -= range;
+    // advance from end to the element that would follow the last
+    // accessible element
+    Iterator end_for_strided_iterator = last;
+    std::advance(end_for_strided_iterator, d + stride);
+    return strided_iterator<Iterator>(end_for_strided_iterator, stride);
 }
 
 /// \internal_ (is_device_iterator specialization for transform_iterator)

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -1,0 +1,242 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ITERATOR_strided_ITERATOR_HPP
+#define BOOST_COMPUTE_ITERATOR_strided_ITERATOR_HPP
+
+#include <cstddef>
+#include <iterator>
+
+#include <boost/config.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
+
+#include <boost/compute/functional.hpp>
+#include <boost/compute/detail/meta_kernel.hpp>
+#include <boost/compute/detail/is_buffer_iterator.hpp>
+#include <boost/compute/detail/read_write_single_value.hpp>
+#include <boost/compute/iterator/detail/get_base_iterator_buffer.hpp>
+#include <boost/compute/type_traits/is_device_iterator.hpp>
+#include <boost/compute/type_traits/result_of.hpp>
+
+namespace boost {
+namespace compute {
+
+// forward declaration for strided_iterator
+template<class Iterator>
+class strided_iterator;
+
+namespace detail {
+
+// helper class which defines the iterator_adaptor super-class
+// type for strided_iterator
+template<class Iterator>
+class strided_iterator_base
+{
+public:
+    typedef ::boost::iterator_adaptor<
+        ::boost::compute::strided_iterator<Iterator>,
+        Iterator
+    > type;
+};
+
+// helper class for including stride value in index
+// expression
+template<class IndexExpr, class Stride>
+struct stride_expr
+{
+    stride_expr(const IndexExpr &expr, Stride stride)
+        : m_index_expr(expr),
+          m_stride(stride)
+    {
+    }
+
+    IndexExpr m_index_expr;
+    Stride m_stride;
+};
+
+template<class IndexExpr, class Stride>
+inline stride_expr<IndexExpr, Stride> make_stride_expr(const IndexExpr &expr, Stride stride)
+{
+    return stride_expr<IndexExpr, Stride>(expr, stride);
+}
+
+template<class IndexExpr, class Stride>
+inline meta_kernel& operator<<(meta_kernel &kernel, const stride_expr<IndexExpr, Stride> &expr)
+{
+    return kernel << "(" << kernel.lit<uint_>(expr.m_stride) << " * (" << expr.m_index_expr << "))";
+}
+
+template<class Iterator, class Stride, class IndexExpr>
+struct strided_iterator_index_expr
+{
+    typedef typename std::iterator_traits<Iterator>::value_type result_type;
+
+    strided_iterator_index_expr(const Iterator &input_iter,
+                                  const Stride &stride,
+                                  const IndexExpr &index_expr)
+        : m_input_iter(input_iter),
+          m_stride(stride),
+          m_index_expr(index_expr)
+    {
+    }
+
+    Iterator m_input_iter;
+    const Stride& m_stride;
+    IndexExpr m_index_expr;
+};
+
+template<class Iterator, class Stride, class IndexExpr>
+inline meta_kernel& operator<<(meta_kernel &kernel,
+                               const strided_iterator_index_expr<Iterator,
+                                                                   Stride,
+                                                                   IndexExpr> &expr)
+{
+    return kernel << expr.m_input_iter[make_stride_expr(expr.m_index_expr, expr.m_stride)];
+}
+
+} // end detail namespace
+
+/// \class strided_iterator
+/// \brief Iterator adaptor which skips over multiple elements each time it is incremented.
+///
+/// TODO
+///
+///
+/// \see buffer_iterator, make_strided_iterator()
+template<class Iterator>
+class strided_iterator :
+    public detail::strided_iterator_base<Iterator>::type
+{
+public:
+    typedef typename
+        detail::strided_iterator_base<Iterator>::type super_type;
+    typedef typename super_type::value_type value_type;
+    typedef typename super_type::reference reference;
+    typedef typename super_type::base_type base_type;
+    typedef typename super_type::difference_type difference_type;
+
+    strided_iterator(Iterator iterator, difference_type stride)
+        : super_type(iterator),
+          m_stride(static_cast<difference_type>(stride))
+    {
+        // stride must be greater than zero
+        BOOST_ASSERT_MSG(stride > 0, "Stride value must be greater than zero");
+    }
+
+    strided_iterator(const strided_iterator<Iterator> &other)
+        : super_type(other.base()),
+          m_stride(other.m_stride)
+    {
+    }
+
+    strided_iterator<Iterator>&
+    operator=(const strided_iterator<Iterator> &other)
+    {
+        if(this != &other){
+            super_type::operator=(other);
+
+            m_stride = other.m_stride;
+        }
+
+        return *this;
+    }
+
+    ~strided_iterator()
+    {
+    }
+
+    size_t get_index() const
+    {
+        return super_type::base().get_index();
+    }
+
+    const buffer& get_buffer() const
+    {
+        return detail::get_base_iterator_buffer(*this);
+    }
+
+    template<class IndexExpression>
+    detail::strided_iterator_index_expr<Iterator, difference_type, IndexExpression>
+    operator[](const IndexExpression &expr) const
+    {
+        return detail::strided_iterator_index_expr<Iterator,
+                                                   difference_type,
+                                                   IndexExpression>(super_type::base(),
+                                                                    m_stride,
+                                                                    expr);
+    }
+
+private:
+    friend class ::boost::iterator_core_access;
+
+    reference dereference() const
+    {
+        return reference();
+    }
+
+    bool equal(const strided_iterator<Iterator> &other) const
+    {
+        return (other.m_stride == m_stride)
+                   && (other.base_reference() == this->base_reference());
+    }
+
+    void increment()
+    {
+        std::advance(super_type::base_reference(), m_stride);
+    }
+
+    void decrement()
+    {
+        std::advance(super_type::base_reference(),-m_stride);
+    }
+
+    void advance(typename super_type::difference_type n)
+    {
+        std::advance(super_type::base_reference(), n * m_stride);
+    }
+
+    difference_type distance_to(const strided_iterator<Iterator> &other) const
+    {
+        return std::distance(this->base_reference(), other.base_reference()) / m_stride;
+    }
+
+private:
+    difference_type m_stride;
+};
+
+/// Returns a strided_iterator for \p iterator with \p stride.
+///
+/// TODO: Better description.
+///
+/// \param iterator
+/// \param stride
+///
+/// \return a \c strided_iterator for \p iterator with \p stride.
+///
+/// For example, to create an iterator which iterates over every second
+/// value in a \c vector<int>:
+/// \code
+/// auto strided_iterator = make_strided_iterator(vec.begin(), 2);
+/// \endcode
+template<class Iterator>
+inline strided_iterator<Iterator>
+make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>::difference_type stride)
+{
+    return strided_iterator<Iterator>(iterator, stride);
+}
+
+/// \internal_ (is_device_iterator specialization for transform_iterator)
+template<class Iterator>
+struct is_device_iterator<strided_iterator<Iterator> > : boost::true_type {};
+
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ITERATOR_TRANSFORM_ITERATOR_HPP

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -8,8 +8,8 @@
 // See http://kylelutz.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
-#ifndef BOOST_COMPUTE_ITERATOR_strided_ITERATOR_HPP
-#define BOOST_COMPUTE_ITERATOR_strided_ITERATOR_HPP
+#ifndef BOOST_COMPUTE_ITERATOR_STRIDED_ITERATOR_HPP
+#define BOOST_COMPUTE_ITERATOR_STRIDED_ITERATOR_HPP
 
 #include <cstddef>
 #include <iterator>
@@ -46,8 +46,7 @@ public:
     > type;
 };
 
-// helper class for including stride value in index
-// expression
+// helper class for including stride value in index expression
 template<class IndexExpr, class Stride>
 struct stride_expr
 {
@@ -104,12 +103,12 @@ inline meta_kernel& operator<<(meta_kernel &kernel,
 } // end detail namespace
 
 /// \class strided_iterator
-/// \brief Iterator adaptor which skips over multiple elements each time it is incremented.
+/// \brief An iterator adaptor with adjustable iteration step.
 ///
-/// TODO: Description
+/// The strided iterator adaptor skips over multiple elements each time
+/// it is incremented or decremented.
 ///
-///
-/// \see buffer_iterator, make_strided_iterator()
+/// \see buffer_iterator, make_strided_iterator(), make_strided_iterator_end()
 template<class Iterator>
 class strided_iterator :
     public detail::strided_iterator_base<Iterator>::type
@@ -213,10 +212,8 @@ private:
 
 /// Returns a strided_iterator for \p iterator with \p stride.
 ///
-/// TODO: Description
-///
-/// \param iterator
-/// \param stride
+/// \param iterator the underlying iterator
+/// \param stride the iteration step for strided_iterator
 ///
 /// \return a \c strided_iterator for \p iterator with \p stride.
 ///
@@ -236,10 +233,12 @@ make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>
 /// the last element accessible through strided_iterator for \p first iterator
 /// with \p stride.
 ///
+/// Parameter \p stride must be greater than zero.
+///
 /// \param first the iterator referring to the first element accessible
 ///        through strided_iterator for \p first with \p stride
-/// \param last the iterator referring to the last element that may be accessible
-///        through strided_iterator for \p first with \p stride
+/// \param last the iterator referring to the last element that may be
+////       accessible through strided_iterator for \p first with \p stride
 /// \param stride the iteration step
 ///
 /// \return a \c strided_iterator referring to element that would follow
@@ -255,7 +254,9 @@ make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>
 /// // copy every 3rd element to result
 /// boost::compute::copy(
 ///         strided_iterator_begin,
-///         strided_iterator_end,
+///         strided_iterator_end,ided_iterator referring to element that would follow
+///         the last element accessible through strided_iterator for \p first
+///         iterator with \p stride.
 ///         result.begin(),
 ///         queue
 /// );
@@ -279,7 +280,7 @@ make_strided_iterator_end(Iterator first, Iterator last, typename std::iterator_
     return strided_iterator<Iterator>(end_for_strided_iterator, stride);
 }
 
-/// \internal_ (is_device_iterator specialization for transform_iterator)
+/// \internal_ (is_device_iterator specialization for strided_iterator)
 template<class Iterator>
 struct is_device_iterator<strided_iterator<Iterator> > : boost::true_type {};
 

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -249,7 +249,7 @@ make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>
 /// \code
 /// // vec.size() may not be divisible by 3
 /// auto strided_iterator_begin = make_strided_iterator(vec.begin(), 3);
-/// auto strided_iterator_end = make_strided_iterator_end(vec.end(), 3);
+/// auto strided_iterator_end = make_strided_iterator_end(vec.begin(), vec.end(), 3);
 ///
 /// // copy every 3rd element to result
 /// boost::compute::copy(
@@ -287,4 +287,4 @@ struct is_device_iterator<strided_iterator<Iterator> > : boost::true_type {};
 } // end compute namespace
 } // end boost namespace
 
-#endif // BOOST_COMPUTE_ITERATOR_TRANSFORM_ITERATOR_HPP
+#endif // BOOST_COMPUTE_ITERATOR_STRIDED_ITERATOR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -163,6 +163,7 @@ add_compute_test("iterator.counting_iterator" test_counting_iterator.cpp)
 add_compute_test("iterator.discard_iterator" test_discard_iterator.cpp)
 add_compute_test("iterator.function_input_iterator" test_function_input_iterator.cpp)
 add_compute_test("iterator.permutation_iterator" test_permutation_iterator.cpp)
+add_compute_test("iterator.strided_iterator" test_strided_iterator.cpp)
 add_compute_test("iterator.transform_iterator" test_transform_iterator.cpp)
 add_compute_test("iterator.zip_iterator" test_zip_iterator.cpp)
 

--- a/test/test_strided_iterator.cpp
+++ b/test/test_strided_iterator.cpp
@@ -55,6 +55,61 @@ BOOST_AUTO_TEST_CASE(base_type)
     ));
 }
 
+BOOST_AUTO_TEST_CASE(distance)
+{
+    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<int> vec(data, data + 8, queue);
+
+    BOOST_CHECK_EQUAL(
+         std::distance(
+             boost::compute::make_strided_iterator(vec.begin(), 1),
+             boost::compute::make_strided_iterator(vec.end(), 1)
+         ),
+         std::ptrdiff_t(8)
+    );
+    BOOST_CHECK_EQUAL(
+        std::distance(
+            boost::compute::make_strided_iterator(vec.begin(), 2),
+            boost::compute::make_strided_iterator(vec.end(), 2)
+        ),
+        std::ptrdiff_t(4)
+    );
+
+    BOOST_CHECK_EQUAL(
+        std::distance(
+            boost::compute::make_strided_iterator(vec.begin(), 3),
+            boost::compute::make_strided_iterator(vec.begin()+6, 3)
+        ),
+        std::ptrdiff_t(2)
+    );
+}
+
+BOOST_AUTO_TEST_CASE(copy)
+{
+    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<int> vec(data, data + 8, queue);
+
+    boost::compute::vector<int> result(4, context);
+
+    // copy every other element to result
+    boost::compute::copy(
+        boost::compute::make_strided_iterator(vec.begin(), 2),
+        boost::compute::make_strided_iterator(vec.end(), 2),
+        result.begin(),
+        queue
+    );
+    CHECK_RANGE_EQUAL(int, 4, result, (1, 3, 5, 7));
+
+    // copy every 3rd element to result
+    boost::compute::copy(
+        boost::compute::make_strided_iterator(vec.begin(), 3),
+        boost::compute::make_strided_iterator(vec.begin()+9, 3),
+        result.begin(),
+        queue
+    );
+    CHECK_RANGE_EQUAL(int, 3, result, (1, 4, 7));
+}
+
 BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
 {
     int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -65,7 +120,7 @@ BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
         boost::compute::make_strided_iterator_end(vec.begin(),
                                                   vec.end(),
                                                   3);
-    // end should be vec.begin() + 9 which one step after last element
+    // end should be vec.begin() + 9 which is one step after last element
     // accessible through strided_iterator, i.e. vec.begin()+6
     BOOST_CHECK(boost::compute::make_strided_iterator(vec.begin()+9, 3) ==
                 end);
@@ -99,61 +154,5 @@ BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
     );
     CHECK_RANGE_EQUAL(int, 4, result, (2, 4, 6, 8));
 }
-
-BOOST_AUTO_TEST_CASE(copy)
-{
-    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    boost::compute::vector<int> vec(data, data + 8, queue);
-
-    boost::compute::vector<int> result(4, context);
-
-    // copy every other element to result
-    boost::compute::copy(
-        boost::compute::make_strided_iterator(vec.begin(), 2),
-        boost::compute::make_strided_iterator(vec.end(), 2),
-        result.begin(),
-        queue
-    );
-    CHECK_RANGE_EQUAL(int, 4, result, (1, 3, 5, 7));
-
-    // copy every 3rd element to result
-    boost::compute::copy(
-        boost::compute::make_strided_iterator(vec.begin(), 3),
-        boost::compute::make_strided_iterator(vec.begin()+9, 3),
-        result.begin(),
-        queue
-    );
-    CHECK_RANGE_EQUAL(int, 3, result, (1, 4, 7));
-}
-
-BOOST_AUTO_TEST_CASE(distance)
-{
-    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    boost::compute::vector<int> vec(data, data + 8, queue);
-
-    BOOST_CHECK_EQUAL(
-         std::distance(
-             boost::compute::make_strided_iterator(vec.begin(), 1),
-             boost::compute::make_strided_iterator(vec.end(), 1)
-         ),
-         std::ptrdiff_t(8)
-    );
-    BOOST_CHECK_EQUAL(
-        std::distance(
-            boost::compute::make_strided_iterator(vec.begin(), 2),
-            boost::compute::make_strided_iterator(vec.end(), 2)
-        ),
-        std::ptrdiff_t(4)
-    );
-
-    BOOST_CHECK_EQUAL(
-        std::distance(
-            boost::compute::make_strided_iterator(vec.begin(), 3),
-            boost::compute::make_strided_iterator(vec.begin()+6, 3)
-        ),
-        std::ptrdiff_t(2)
-    );
-}
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_strided_iterator.cpp
+++ b/test/test_strided_iterator.cpp
@@ -1,0 +1,121 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestSkipIterator
+#include <boost/test/unit_test.hpp>
+
+#include <iterator>
+
+#include <boost/type_traits.hpp>
+#include <boost/static_assert.hpp>
+
+#include <boost/compute/algorithm/copy.hpp>
+#include <boost/compute/container/vector.hpp>
+#include <boost/compute/iterator/strided_iterator.hpp>
+
+#include "check_macros.hpp"
+#include "context_setup.hpp"
+
+BOOST_AUTO_TEST_CASE(value_type)
+{
+    BOOST_STATIC_ASSERT((
+        boost::is_same<
+            boost::compute::strided_iterator<
+                boost::compute::buffer_iterator<int>
+            >::value_type,
+            int
+        >::value
+    ));
+    BOOST_STATIC_ASSERT((
+        boost::is_same<
+            boost::compute::strided_iterator<
+                boost::compute::buffer_iterator<float>
+            >::value_type,
+            float
+        >::value
+    ));
+}
+
+BOOST_AUTO_TEST_CASE(base_type)
+{
+    BOOST_STATIC_ASSERT((
+        boost::is_same<
+            boost::compute::strided_iterator<
+                boost::compute::buffer_iterator<int>
+            >::base_type,
+            boost::compute::buffer_iterator<int>
+        >::value
+    ));
+}
+
+BOOST_AUTO_TEST_CASE(copy)
+{
+    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<int> vec(data, data + 8, queue);
+
+    boost::compute::vector<int> result(4, context);
+
+    // copy every other element to result
+    boost::compute::copy(
+        boost::compute::make_strided_iterator(vec.begin(), 2),
+        boost::compute::make_strided_iterator(vec.end(), 2),
+        result.begin(),
+        queue
+    );
+    CHECK_RANGE_EQUAL(int, 4, result, (1, 3, 5, 7));
+
+    // copy every other element to result
+    boost::compute::copy(
+        boost::compute::make_strided_iterator(vec.begin(), 3),
+        boost::compute::make_strided_iterator(vec.begin()+6, 3),
+        result.begin(),
+        queue
+    );
+    CHECK_RANGE_EQUAL(int, 2, result, (1, 4));
+}
+
+BOOST_AUTO_TEST_CASE(distance)
+{
+    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<int> vec(data, data + 8, queue);
+
+    BOOST_CHECK_EQUAL(
+         std::distance(
+             boost::compute::make_strided_iterator(vec.begin(), 1),
+             boost::compute::make_strided_iterator(vec.end(), 1)
+         ),
+         std::ptrdiff_t(8)
+    );
+    BOOST_CHECK_EQUAL(
+        std::distance(
+            boost::compute::make_strided_iterator(vec.begin(), 2),
+            boost::compute::make_strided_iterator(vec.end(), 2)
+        ),
+        std::ptrdiff_t(4)
+    );
+    BOOST_CHECK_EQUAL(
+        std::distance(
+            boost::compute::make_strided_iterator(vec.begin(), 4),
+            boost::compute::make_strided_iterator(vec.end(), 4)
+        ),
+        std::ptrdiff_t(2)
+    );
+
+    BOOST_CHECK_EQUAL(
+        std::distance(
+            boost::compute::make_strided_iterator(vec.begin(), 3),
+            boost::compute::make_strided_iterator(vec.begin()+6, 3)
+        ),
+        std::ptrdiff_t(2)
+    );
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This addresses issue #121.

I've added ```strided_iterator``` adaptor which - as requested - skips over multiple elements each time it is incremented. It's called strided_iterator to match corresponding iterator in the Boost.Range library (see [boost/range/adaptor/strided.hpp](http://www.boost.org/doc/libs/1_58_0/boost/range/adaptor/strided.hpp)). Tests included. 

I've also included function ```make_strided_iterator_end()```. It may be useful. What do you think about it?

@kylelutz, thank you for providing your code. It was helpful.